### PR TITLE
feat: Enhance replay functionality and user flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
     <div class="btn" id="left">←</div> <div class="btn" id="down">↓</div> <div class="btn" id="right">→</div>
   </div>
 
-  <a id="replay-link" href="#" target="_blank" style="display:none;">分享你的上一局回放！</a>
+  <a id="replay-link" href="#" style="display:none;">分享你的上一局回放！</a>
 
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
@@ -73,11 +73,21 @@
           snake: JSON.parse(JSON.stringify(snake)),
           apple: { ...apple }
       };
-      replayLink.style.display = "none";
+      // 移除 replayLink.style.display = "none";
       statusText.innerText = "請按 Enter 或觸控方向鍵開始";
     }
 
     resetGame();
+
+    // 新增：頁面載入時檢查是否有從回放頁返回
+    window.addEventListener('load', () => {
+        const urlParams = new URLSearchParams(window.location.search);
+        const lastReplayUrl = urlParams.get('last_replay_url');
+        if (lastReplayUrl) {
+            replayLink.href = lastReplayUrl;
+            replayLink.style.display = 'block';
+        }
+    });
 
     function handleDirectionChange(newDx, newDy, moveCode) {
         dx = newDx;
@@ -86,9 +96,15 @@
     }
 
     document.addEventListener("keydown", (e) => {
-      if (gameOver && e.key === "Enter") { resetGame(); return; }
+      if (gameOver && e.key === "Enter") {
+        resetGame();
+        // 這時候不清空 replay link，讓玩家可以再次點擊
+        return;
+      }
       if (!started) {
+        // 當玩家按下方向鍵或 Enter 開始新遊戲時，才隱藏回放按鈕
         if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Enter"].includes(e.key)) {
+          replayLink.style.display = 'none'; // 在這裡隱藏
           started = true;
           statusText.innerText = "";
           if (e.key === "ArrowUp") handleDirectionChange(0, -1, 'u');

--- a/replay.html
+++ b/replay.html
@@ -19,6 +19,7 @@
 </head>
 <body>
   <h1>🐍 遊戲回放</h1>
+  <p style="color: #ffcc00; font-size: 14px; margin: -5px 0 10px 0;">請務必記住此網址連結 開始下一場遊戲後你就回不來了!</p>
   <p id="replay-status">載入中...</p>
   <canvas id="game" width="400" height="400"></canvas>
   <input type="range" id="progress-slider" value="0" step="1">
@@ -217,6 +218,15 @@
               pause();
               drawFrame(parseInt(e.target.value));
           });
+
+          // 新增：監聽空白鍵來播放/暫停
+          document.addEventListener('keydown', (e) => {
+            if (e.code === 'Space') {
+              e.preventDefault(); // 防止頁面滾動
+              togglePlayPause();
+            }
+          });
+
         } else {
           statusText.textContent = "錯誤：在資料庫中找不到這個回放紀錄。";
         }
@@ -226,7 +236,15 @@
       }
     }
 
+    // 修改 back-link 的 href，將當前回放 URL 傳回去
+    function setBackLink() {
+        const backLink = document.getElementById('back-link');
+        const currentUrl = window.location.href;
+        backLink.href = `index.html?last_replay_url=${encodeURIComponent(currentUrl)}`;
+    }
+
     initializeReplay();
+    setBackLink();
   </script>
 </body>
 </html>


### PR DESCRIPTION
This commit implements several user-requested improvements to the game's replay feature.

- The 'Share your last replay!' button now navigates to the replay page in the same tab instead of opening a new one.
- On the replay page, users can now press the Spacebar to play or pause the replay.
- A warning message has been added to the replay page to remind users to save the URL.
- The 'Share your last replay!' button now persists on the main page after returning from a replay. It is only hidden when the user starts a new game, improving the user experience.