### PR TITLE
feat: Ensure deterministic replays and refactor game flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
     const tileCount = canvas.width / gridSize;
 
     let snake, apple, dx, dy, score, bestScore, frameCount;
-    let gameHistory, initialState;
+    let gameHistory, initialState, appleHistory;
     let gameState = 'initial'; // 'initial', 'playing', 'gameOver'
 
     bestScore = parseInt(localStorage.getItem("bestScore")) || 0;
@@ -69,6 +69,7 @@
       gameState = 'initial';
       frameCount = 0;
       gameHistory = [];
+      appleHistory = [{ ...apple, frame: 0 }]; // 初始化並記錄第一顆蘋果
       initialState = {
           snake: JSON.parse(JSON.stringify(snake)),
           apple: { ...apple }
@@ -167,6 +168,7 @@
         const replayDoc = await db.collection("replays").add({
           initialState: initialState,
           moves: gameHistory,
+          appleHistory: appleHistory, // 新增
           finalScore: score,
           createdAt: firebase.firestore.FieldValue.serverTimestamp()
         });
@@ -187,6 +189,7 @@
         const replayDoc = await db.collection("replays").add({
           initialState: initialState,
           moves: gameHistory,
+          appleHistory: appleHistory, // 新增
           finalScore: score,
           createdAt: firebase.firestore.FieldValue.serverTimestamp()
         });
@@ -242,6 +245,7 @@
 
         if (emptyCells.length > 0) {
           apple = emptyCells[Math.floor(Math.random() * emptyCells.length)];
+          appleHistory.push({ ...apple, frame: frameCount }); // 新增：記錄新蘋果的位置和影格
         } else {
           // 如果沒有空位，這本身就是勝利條件
           // 雖然前面已經有檢查，但這裡再次調用以確保萬無一失

--- a/replay.html
+++ b/replay.html
@@ -106,34 +106,30 @@
     }
 
     // --- 【最終修改】以絕對精準的時序重寫回放引擎 ---
-    function generateFramesFromHistory(initialState, moves) {
+    function generateFramesFromHistory(initialState, moves, appleHistory) {
         let snake = JSON.parse(JSON.stringify(initialState.snake));
         let apple = { ...initialState.apple };
         let score = 0;
         let dx = 0, dy = 0; // 遊戲開始時是靜止的
         let frameCount = 0;
         let moveIndex = 0;
+        let appleIndex = 1; // 從第二顆蘋果開始讀取
         const generatedFrames = [];
 
         // 遊戲開始時，如果沒有立即的操作，預設一個初始方向 (向右)
-        // 這確保了即使第一個指令在好幾幀之後，蛇也會從一開始就移動
         if (moves.length === 0 || moves[0].frame > 0) {
             dx = 1; dy = 0;
         }
 
-        const MAX_FRAMES = 15000; // 安全機制，防止意外的無限迴圈
+        const MAX_FRAMES = 15000; // 安全機制
 
         while (frameCount < MAX_FRAMES) {
-            // 1. 儲存當前幀 (N) 的狀態，用於繪製。
-            // 這個狀態是基於 N-1 幀的指令計算而來的。
             generatedFrames.push({
                 snake: JSON.parse(JSON.stringify(snake)),
                 apple: { ...apple },
                 score: score
             });
 
-            // 2. 檢查在當前幀 (N)，玩家是否按下了按鍵。
-            // 這個指令將決定 N+1 幀的移動方向。
             if (moveIndex < moves.length && moves[moveIndex].frame === frameCount) {
                 const move = moves[moveIndex].move;
                 if (move === 'u' && dy === 0) { dx = 0; dy = -1; }
@@ -143,56 +139,43 @@
                 moveIndex++;
             }
 
-            // 如果還沒收到第一個指令，蛇保持不動
-            if (dx === 0 && dy === 0) {
+            if (dx === 0 && dy === 0 && frameCount > 0) {
                 frameCount++;
                 continue;
             }
 
-            // 3. 計算蛇頭在下一幀的位置 (使用當前的 dx, dy)
             const head = { x: snake[0].x + dx, y: snake[0].y + dy };
 
-            // 4. 檢查是否遊戲結束 (撞牆或撞自己)
             if (head.x < 0 || head.x >= tileCount || head.y < 0 || head.y >= tileCount || snake.some(s => s.x === head.x && s.y === head.y)) {
-                break; // 遊戲結束，停止模擬
+                break;
             }
 
-            // 5. 更新蛇的狀態
             snake.unshift(head);
 
             if (head.x === apple.x && head.y === apple.y) {
                 score++;
-                // 檢查勝利條件
                 if (snake.length >= tileCount * tileCount) {
-                    break; // 勝利，停止模擬
-                }
-                // 【修復】使用與 index.html 同步的、可靠的方法生成新蘋果
-                const emptyCells = [];
-                const snakeCellSet = new Set(snake.map(s => `${s.x},${s.y}`));
-
-                for (let x = 0; x < tileCount; x++) {
-                    for (let y = 0; y < tileCount; y++) {
-                        if (!snakeCellSet.has(`${x},${y}`)) {
-                            emptyCells.push({ x, y });
-                        }
-                    }
-                }
-
-                if (emptyCells.length > 0) {
-                    apple = emptyCells[Math.floor(Math.random() * emptyCells.length)];
-                } else {
-                    // 如果沒有空位（勝利），則停止模擬
+                    generatedFrames.push({ // 捕獲吃掉最後一個蘋果的幀
+                        snake: JSON.parse(JSON.stringify(snake)),
+                        apple: { ...apple },
+                        score: score
+                    });
                     break;
+                }
+                // 【修復】不再隨機生成，而是從歷史紀錄中讀取
+                if (appleIndex < appleHistory.length) {
+                    apple = appleHistory[appleIndex];
+                    appleIndex++;
                 }
             } else {
                 snake.pop();
             }
 
-            // 6. 推進時間
             frameCount++;
         }
         return generatedFrames;
     }
+
 
     async function initializeReplay() {
       const urlParams = new URLSearchParams(window.location.search);
@@ -209,9 +192,13 @@
 
         if (doc.exists) {
           const data = doc.data();
+          if (!data.appleHistory) {
+              statusText.textContent = "錯誤：這是一個舊版的回放紀錄，缺少蘋果位置資料，無法播放。";
+              return;
+          }
           statusText.textContent = "正在產生回放畫面...";
 
-          replayData = generateFramesFromHistory(data.initialState, data.moves);
+          replayData = generateFramesFromHistory(data.initialState, data.moves, data.appleHistory);
 
           if (replayData.length === 0) {
               statusText.textContent = "錯誤：無法生成回放資料，可能是紀錄有問題。";


### PR DESCRIPTION
This commit resolves a critical bug that caused inconsistencies between live gameplay and the replay, and implements several user-requested UX enhancements.

Key Changes:

- **Deterministic Replays**:
  - An `appleHistory` array is now recorded during gameplay in `index.html`, storing the exact frame and coordinates of each apple.
  - This history is saved to Firebase along with the move data.
  - The replay engine in `replay.html` now uses this `appleHistory` to reconstruct the game perfectly, ensuring the replay is 100% accurate.

- **Game State Refactor**:
  - A `gameState` variable ('initial', 'playing', 'gameOver') has been introduced in `index.html` to create a robust and clear state machine.
  - This resolves logical errors related to the "second Enter press" to restart the game and correctly manages the replay button's visibility.

- **UX Enhancements**:
  - The "Share Replay" button now opens in the same tab.
  - Spacebar can now be used to play/pause on the replay page.
  - A warning message has been added to the replay page.
  - The replay link correctly persists after viewing a replay and is only hidden when a new game begins.

- **Bug Fixes**:
  - The primary inconsistency bug is resolved.
  - The previously fixed infinite-loop bug in the apple generation algorithm remains correctly implemented.