### PR TITLE
revert: Revert attempt to separate Firebase configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-# Firebase config file
-firebase-config.js

--- a/index.html
+++ b/index.html
@@ -46,9 +46,17 @@
 
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
-  <script src="firebase-config.js"></script>
 
   <script>
+    const firebaseConfig = {
+      apiKey: "AIzaSyAtkZyxuP2alDTUm1AA7EAlPYSvvZAznEI",
+      authDomain: "cogent-altar-468009-p7.firebaseapp.com",
+      projectId: "cogent-altar-468009-p7",
+      storageBucket: "cogent-altar-468009-p7.firebasestorage.app",
+      messagingSenderId: "849610525376",
+      appId: "1:849610525376:web:154b5103d027710734fb25"
+    };
+
     firebase.initializeApp(firebaseConfig);
     const db = firebase.firestore();
 

--- a/replay.html
+++ b/replay.html
@@ -32,9 +32,17 @@
 
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
-  <script src="firebase-config.js"></script>
 
   <script>
+    const firebaseConfig = {
+      apiKey: "AIzaSyAtkZyxuP2alDTUm1AA7EAlPYSvvZAznEI",
+      authDomain: "cogent-altar-468009-p7.firebaseapp.com",
+      projectId: "cogent-altar-468009-p7",
+      storageBucket: "cogent-altar-468009-p7.firebasestorage.app",
+      messagingSenderId: "849610525376",
+      appId: "1:849610525376:web:154b5103d027710734fb25"
+    };
+
     firebase.initializeApp(firebaseConfig);
     const db = firebase.firestore();
 


### PR DESCRIPTION
This commit reverts the changes made in the attempt to separate the Firebase configuration into an external `firebase-config.js` file.

The previous attempt was incomplete as it failed to include the new `firebase-config.js` file in the changeset, which broke the application's functionality.

This revert restores the project to a stable, working state by:
- Re-embedding the `firebaseConfig` object directly into `index.html` and `replay.html`.
- Removing the `<script>` tags that referenced the non-existent external file.
- Deleting the now-unused `firebase-config.js` and `.gitignore` files that were created during the attempt.